### PR TITLE
Trim whitespace from GradleVersion.txt file

### DIFF
--- a/Editor/GradleWrapperSettings.cs
+++ b/Editor/GradleWrapperSettings.cs
@@ -14,7 +14,7 @@ namespace Gilzoide.GradleWrapperGenerator.Editor
 
         public static string GradleVersion
         {
-            get => File.Exists(GRADLE_VERSION_FILE_PATH) ? File.ReadAllText(GRADLE_VERSION_FILE_PATH) : "";
+            get => File.Exists(GRADLE_VERSION_FILE_PATH) ? File.ReadAllText(GRADLE_VERSION_FILE_PATH).Trim() : "";
             set
             {
                 if (string.IsNullOrWhiteSpace(value))


### PR DESCRIPTION
Our IDEs and CI expects all files to have a blank line at the end of all files.

This newline breaks this plugin's implementation.

The trim removes this newline.