### PR TITLE
Generate wrapper with --no-daemon

### DIFF
--- a/Editor/GradleWrapperGenerator.cs
+++ b/Editor/GradleWrapperGenerator.cs
@@ -38,7 +38,7 @@ namespace Gilzoide.GradleWrapperGenerator.Editor
             var startInfo = new ProcessStartInfo()
             {
                 FileName = FindJavaExecutable(),
-                Arguments = $"-jar \"{FindGradleJar()}\" wrapper --gradle-version {gradleVersion} -b {emptyGradleScriptFile}",
+                Arguments = $"-jar \"{FindGradleJar()}\" wrapper --gradle-version {gradleVersion} -b {emptyGradleScriptFile} --no-daemon",
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,


### PR DESCRIPTION
On Windows, a running daemon that is started during the Unity build can lead to powershell thinking the build is still running.

Using --no-daemon means the daemon should be stopped at the end.