### PR TITLE
Fix support for Gradle 8.11

### DIFF
--- a/Editor/GradleWrapperPaths.cs
+++ b/Editor/GradleWrapperPaths.cs
@@ -41,7 +41,8 @@ namespace Gilzoide.GradleWrapperGenerator.Editor
 #else
             string gradleRoot = Path.Combine(GetUnityAndroidPlayerRoot(), "Tools", "gradle");
 #endif
-            return FindFirstFileWithPattern(Path.Combine(gradleRoot, "lib"), "gradle-launcher*.jar");
+            return FindFirstFileWithPattern(Path.Combine(gradleRoot, "lib"), "gradle-gradle-cli-main*.jar")
+                ?? FindFirstFileWithPattern(Path.Combine(gradleRoot, "lib"), "gradle-launcher*.jar");
         }
 
         public static string FindGradleVersion()

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.1",
   "description": "Generates a Gradle Wrapper (gradlew) when exporting Android projects.\n\nJust choose the desired version in Gradle Wrapper Project Settings and that's it!\nThe plugin will use the Java and Gradle configured in Unity for generating the wrapper, so there's no need to configure anything else.",
   "displayName": "Gradle Wrapper Generator",
-  "unity": "2018.2",
+  "unity": "2021.2",
   "license": "Unlicense",
   "author": {
     "name": "Gil Reis"


### PR DESCRIPTION
In the new versions, the main class is in gradle-gradle-cli-main.jar instead of gradle-launcher.jar.
Fixes #9.